### PR TITLE
Fix obs client error when there is no mic/aux hardware in computer

### DIFF
--- a/ducktrack/obs_client.py
+++ b/ducktrack/obs_client.py
@@ -145,7 +145,13 @@ class OBSClient:
         self.req_client.set_profile_parameter("SimpleOutput", "FilePath", recording_path)
     
         # TODO: not all OBS configs have this, maybe just instruct the user to mute themselves
-        self.req_client.set_input_mute("Mic/Aux", muted=True)
+
+
+        try:
+            self.req_client.set_input_mute("Mic/Aux", muted=True)
+        except obs.error.OBSSDKRequestError :
+            # In case there is no Mic/Aux input, this will throw an error
+            pass
 
     def start_recording(self):
         self.req_client.start_record()


### PR DESCRIPTION
Fantastic project!
I encountered a small bug when trying to run it on my new host which has no mic "xxx.OBSSDKRequestError. xxxx", I think it shouldn't act corrupted just because of the mic hardware, so I fixed it a little bit on my way.
Please check if it is helpful, looking forward to pushing this direction together.