### PR TITLE
Fix OBSSDKRequestError import for newer obsws-python

### DIFF
--- a/ducktrack/obs_client.py
+++ b/ducktrack/obs_client.py
@@ -3,6 +3,7 @@ import subprocess
 import time
 from platform import system
 
+from obsws_python.error import OBSSDKRequestError
 import obsws_python as obs
 import psutil
 
@@ -149,9 +150,9 @@ class OBSClient:
 
         try:
             self.req_client.set_input_mute("Mic/Aux", muted=True)
-        except obs.error.OBSSDKRequestError :
-            # In case there is no Mic/Aux input, this will throw an error
+        except OBSSDKRequestError:
             pass
+            # In case there is no Mic/Aux input, this will throw an error
 
     def start_recording(self):
         self.req_client.start_record()


### PR DESCRIPTION
## What

Fixes a crash when running against recent versions of `obsws-python`. The exception handler added in #9 references `obs.error.OBSSDKRequestError`, but newer releases of `obsws-python` no longer import the `error` module as a package attribute — so when the Mic/Aux mute request fails (e.g. no mic input exists), the `except` clause itself raises `AttributeError` instead of catching the error.

The fix imports `OBSSDKRequestError` directly from `obsws_python.error`, which works across old and new library versions.

## Credit

This fix was authored by @ruiqurm and cherry-picked (authorship preserved) from the [`obs_latest_fix` branch of the SAAgent/DuckTrack fork](https://github.com/SAAgent/DuckTrack/tree/obs_latest_fix), which was never submitted upstream. Thank you!

🤖 Generated with [Claude Code](https://claude.com/claude-code)